### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,5 +1,8 @@
 name: ShellCheck
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/eserlxl/lightXDE/security/code-scanning/1](https://github.com/eserlxl/lightXDE/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only runs ShellCheck on a script file (`install.sh`), it likely only requires read access to the repository contents. We will add the `permissions` key at the root level of the workflow to apply minimal permissions (`contents: read`) to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
